### PR TITLE
feat: Add Telegram signals channel bot

### DIFF
--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -1,0 +1,108 @@
+"""
+DeepAlpha Telegram Signals Bot
+
+Broadcasts free AI-generated trading signals to a public Telegram channel.
+Reads signals from the DeepAlpha engine and posts them formatted with:
+- LONG/SHORT direction
+- Coin/asset pair
+- Confidence score
+- Entry price
+- Take profit / Stop loss levels
+"""
+
+import os
+import json
+import logging
+import requests
+from datetime import datetime
+from typing import Optional
+
+import config
+
+logger = logging.getLogger('deepalpha.telegram')
+
+# Telegram configuration
+BOT_TOKEN = os.getenv('TELEGRAM_BOT_TOKEN', '')
+CHANNEL_ID = os.getenv('TELEGRAM_CHANNEL_ID', '@DeepAlphaSignals')
+
+# Signal template
+SIGNAL_TEMPLATE = """🚀 *DeepAlpha Signal*
+
+*{direction}* {pair}
+Confidence: {confidence}%
+Entry: ${entry}
+Take Profit: ${tp}
+Stop Loss: ${sl}
+
+{reasoning}
+
+#DeepAlpha #CryptoSignals #AI
+"""
+
+
+def send_telegram_message(text: str, parse_mode: str = 'Markdown') -> bool:
+    """Send a message to the configured Telegram channel."""
+    if not BOT_TOKEN:
+        logger.error('TELEGRAM_BOT_TOKEN not configured')
+        return False
+
+    url = f'https://api.telegram.org/bot{BOT_TOKEN}/sendMessage'
+    payload = {
+        'chat_id': CHANNEL_ID,
+        'text': text,
+        'parse_mode': parse_mode,
+        'disable_web_page_preview': True,
+    }
+
+    try:
+        r = requests.post(url, json=payload, timeout=10)
+        r.raise_for_status()
+        logger.info('Signal sent to %s', CHANNEL_ID)
+        return True
+    except requests.RequestException as e:
+        logger.error('Failed to send Telegram message: %s', e)
+        return False
+
+
+def format_signal(signal: dict) -> str:
+    """Format a trading signal dict into a Telegram message."""
+    return SIGNAL_TEMPLATE.format(
+        direction='🟢 LONG' if signal.get('direction', '').upper() == 'LONG' else '🔴 SHORT',
+        pair=signal.get('pair', 'UNKNOWN'),
+        confidence=signal.get('confidence', 0),
+        entry=signal.get('entry', 0),
+        tp=signal.get('take_profit', 0),
+        sl=signal.get('stop_loss', 0),
+        reasoning=signal.get('reasoning', 'AI analysis complete.')
+    )
+
+
+def send_signal(signal: dict) -> bool:
+    """Send a structured trading signal to the Telegram channel."""
+    message = format_signal(signal)
+    return send_telegram_message(message)
+
+
+def send_status(message: str) -> bool:
+    """Send a status/info message to the channel."""
+    return send_telegram_message(f'📊 *DeepAlpha Status*\n{message}')
+
+
+def send_error(message: str) -> bool:
+    """Send an error alert to the channel."""
+    return send_telegram_message(f'⚠️ *DeepAlpha Alert*\n{message}')
+
+
+if __name__ == '__main__':
+    # Test signal
+    test_signal = {
+        'direction': 'LONG',
+        'pair': 'BTC/USDT',
+        'confidence': 87,
+        'entry': 84500,
+        'take_profit': 92000,
+        'stop_loss': 80000,
+        'reasoning': 'Strong bullish divergence detected on 4H RSI with increasing volume. Key resistance broken.'
+    }
+    success = send_signal(test_signal)
+    print(f'Test signal sent: {success}')

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -1,0 +1,101 @@
+"""Tests for the DeepAlpha Telegram bot."""
+
+import json
+import pytest
+from unittest.mock import patch
+
+from telegram_bot import (
+    format_signal,
+    send_telegram_message,
+    send_signal,
+    SIGNAL_TEMPLATE,
+)
+
+
+def test_format_signal_long():
+    """Test formatting a LONG signal."""
+    signal = {
+        'direction': 'LONG',
+        'pair': 'BTC/USDT',
+        'confidence': 87,
+        'entry': 84500,
+        'take_profit': 92000,
+        'stop_loss': 80000,
+        'reasoning': 'Strong bullish divergence detected.',
+    }
+    result = format_signal(signal)
+    assert 'LONG' in result
+    assert 'BTC/USDT' in result
+    assert '87' in result
+    assert '84500' in result
+    assert '92000' in result
+    assert '80000' in result
+    assert 'Strong bullish divergence' in result
+
+
+def test_format_signal_short():
+    """Test formatting a SHORT signal."""
+    signal = {
+        'direction': 'SHORT',
+        'pair': 'ETH/USDT',
+        'confidence': 72,
+        'entry': 3200,
+        'take_profit': 2800,
+        'stop_loss': 3500,
+        'reasoning': 'Bearish flag pattern on 1H.',
+    }
+    result = format_signal(signal)
+    assert 'SHORT' in result
+    assert 'ETH/USDT' in result
+    assert '72' in result
+
+
+def test_format_signal_missing_fields():
+    """Test formatting handles missing fields gracefully."""
+    signal = {
+        'direction': 'LONG',
+        'pair': 'UNKNOWN',
+    }
+    result = format_signal(signal)
+    assert 'LONG' in result
+
+
+@patch('telegram_bot.requests.post')
+def test_send_telegram_message_success(mock_post):
+    """Test successful Telegram message send."""
+    mock_post.return_value.status_code = 200
+    mock_post.return_value.raise_for_status.return_value = None
+
+    import telegram_bot
+    telegram_bot.BOT_TOKEN = 'test:token'
+    result = send_telegram_message('Test message')
+    assert result is True
+
+
+@patch('telegram_bot.requests.post')
+def test_send_telegram_message_no_token(mock_post):
+    """Test send fails gracefully when token is missing."""
+    import telegram_bot
+    telegram_bot.BOT_TOKEN = ''
+    result = send_telegram_message('Test message')
+    assert result is False
+
+
+def test_send_signal():
+    """Test sending a signal wraps properly."""
+    signal = {
+        'direction': 'LONG',
+        'pair': 'TEST/USDT',
+        'confidence': 95,
+        'entry': 100,
+        'take_profit': 120,
+        'stop_loss': 90,
+        'reasoning': 'Test signal.',
+    }
+    with patch('telegram_bot.send_telegram_message') as mock_send:
+        mock_send.return_value = True
+        result = send_signal(signal)
+        assert result is True
+        mock_send.assert_called_once()
+        args = mock_send.call_args[0][0]
+        assert 'TEST/USDT' in args


### PR DESCRIPTION
## Implementation

Added a Telegram signals channel bot for broadcasting AI-generated trading signals.

### Changes

- New telegram_bot.py module
- Formatted signal messages with direction, pair, confidence, entry, TP, SL
- Comprehensive test suite (6/6 passing)
- Handles missing config gracefully

### Features

- Sends formatted LONG/SHORT signals to Telegram channel
- Configurable bot token and channel ID via env vars
- Markdown formatting for clear signal display
- Failed sends are logged, not crashy

### Configuration

Set TELEGRAM_BOT_TOKEN and TELEGRAM_CHANNEL_ID environment variables.

### Test Results

All 6 tests passing.

### Payment

BTC: 1Ast5dKr9z1bLWFBnyh6WDQSgyL7EHJosp